### PR TITLE
Fixed license format in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "reader",
     "scanner"
   ],
-  "license": "Apache License Version 2.0",
+  "license": "Apache-2.0",
   "ignore": [
     "**/.*",
     "node_modules",


### PR DESCRIPTION
Bower accepts either SPDX format or a link to the license.